### PR TITLE
Fixing cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,19 @@ CHECK_INCLUDE_FILE("/opt/vc/include/bcm_host.h" RASPBERRY_PI)
 # Dependant on operating system type we set the flags
 # Accordingly
 #
-if (DEFINED RASPBERRY_PI)
+if (EXISTS "/opt/vc/include/bcm_host.h")
+    # RASPBERRY PI
     message(STATUS "Detected a RaspberryPi System")
 elseif(APPLE)
+    # APPLE
     set(CMAKE_SYSTEM_NAME Darwin)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     message(STATUS "Detected an Apple System")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    # OTHER LINUX
     message(STATUS "Detected a Linux System")
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN mkdir -p build
 WORKDIR /code/build
 RUN cmake ..
 RUN make -j
+WORKDIR /code
 
-CMD servo --config=files/examples/servod-dummy.conf
+CMD ./build/servod --config=files/examples/servod-dummy.conf
 
 EXPOSE 2047

--- a/tests/Hardware/Servo.cpp
+++ b/tests/Hardware/Servo.cpp
@@ -82,7 +82,10 @@ void Servo::testExceptionInvalidNegativeTarget()
  */
 void Servo::testExceptionInvalidLargePositiveTarget()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverflow"
     this->servo->setTarget(100084);
+#pragma GCC diagnostic pop
 }
 
 /**
@@ -91,7 +94,10 @@ void Servo::testExceptionInvalidLargePositiveTarget()
  */
 void Servo::testExceptionInvalidLargeNegativeTarget()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverflow"
     this->servo->setTarget(-234128989934832);
+#pragma GCC diagnostic pop
 }
 
 /**

--- a/tests/Hardware/ServoController.cpp
+++ b/tests/Hardware/ServoController.cpp
@@ -132,7 +132,10 @@ void ServoController::testExceptionInvalidNegativeTarget()
  */
 void ServoController::testExceptionInvalidLargePositiveTarget()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverflow"
     this->servoController->setTarget(1, 100084);
+#pragma GCC diagnostic pop
 }
 
 /**
@@ -141,7 +144,10 @@ void ServoController::testExceptionInvalidLargePositiveTarget()
  */
 void ServoController::testExceptionInvalidLargeNegativeTarget()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverflow"
     this->servoController->setTarget(1, -234128989934832);
+#pragma GCC diagnostic pop
 }
 
 /**


### PR DESCRIPTION
Warnings for tests are suppressed because they are testing such problems. And `std=c++11` is generic as the using the correct `g++` works the same for all OS's